### PR TITLE
Fix artifact action version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
           cache: 'npm'
       - run: npm install
       - run: npm run build
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: dist
 


### PR DESCRIPTION
## Summary
- use actions/upload-pages-artifact v4 in deploy workflow

## Testing
- `npm run build` *(fails: astro: not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e8e80bd7483309f8cfa32b899b789