### PR TITLE
Update workflow for valid actions version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
           cache: 'npm'
       - run: npm install
       - run: npm run build
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: dist
 


### PR DESCRIPTION
## Summary
- fix the GitHub Pages upload action version in the workflow

## Testing
- `npm install` *(fails: 403 Forbidden / no network)*
- `npm run build` *(fails: `astro: not found`)*


------
https://chatgpt.com/codex/tasks/task_e_687e95073ebc8330ad0db33558457dc3