### PR TITLE
Fix CI by removing npm cache step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '20'
-          cache: 'npm'
       - run: npm install
       - run: npm run build
       - uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- remove `cache: npm` from workflow because no lock file is checked in

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e96cff7e4833096b64f442e055a3e