### PR TITLE
Fix front matter for GitHub Pages

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,12 +1,9 @@
----
-const { title } = Astro.props;
----
 <!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{title}</title>
+    <title>{Astro.props.title}</title>
   </head>
   <body>
     <slot />


### PR DESCRIPTION
## Summary
- fix YAML front matter error by removing front matter from layout

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e9718b9c0833098f2ce750746c30b