### PR TITLE
Fix GitHub Pages deployment

### DIFF
--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -9,3 +9,5 @@ Dies ist eine einfache Webseite, die mit [Astro](https://astro.build) erstellt w
 
 Sie können Seiten als Markdown-Dateien hinzufügen und GitHub Actions baut die Seite automatisch.
 
+
+Diese Seite wurde soeben aktualisiert und sollte nun über GitHub Pages sichtbar sein.


### PR DESCRIPTION
## Summary
- rename `. nojekyll` to `.nojekyll` so GitHub Pages does not run Jekyll
- update the homepage text to verify the latest deployment

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687e9e83dc5483308a80b706533af0b6