### PR TITLE
Fix GitHub workflow to build Astro site

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,8 +1,7 @@
-# Sample workflow for building and deploying a Jekyll site to GitHub Pages
-name: Deploy Jekyll with GitHub Pages dependencies preinstalled
+# Build and deploy the Astro site to GitHub Pages
+name: Deploy Astro to GitHub Pages
 
 on:
-  # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
 
@@ -22,21 +21,23 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Build job
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-      - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
-          source: ./
-          destination: ./_site
+          node-version: 20
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
 
   # Deployment job
   deploy:

--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ npm run dev
 
 ## Deployment
 
-Das Deployment erfolgt automatisch über den Workflow in `.github/workflows/jekyll-gh-pages.yml`. Die gebaute Seite wird auf dem Branch `gh-pages` veröffentlicht.
+Das Deployment erfolgt automatisch über den Workflow in `.github/workflows/jekyll-gh-pages.yml`. Dabei wird die Astro-Seite gebaut und anschließend auf dem Branch `gh-pages` veröffentlicht.
 


### PR DESCRIPTION
## Summary
- update CI workflow to build with Node and Astro
- clarify README about workflow

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ea1378e088330b4e9cb4e89bd0a4e