### PR TITLE
Use npm install in workflow

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           node-version: 20
       - name: Install dependencies
-        run: npm ci
+        run: npm install
       - name: Build
         run: npm run build
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- fix GH Actions by using `npm install` instead of `npm ci`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f453d7cc08330b2cf7996f25baf2c