### PR TITLE
Update to black and white responsive design

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="200" height="80">
-  <rect width="100%" height="100%" fill="#0F4C81" />
+  <rect width="100%" height="100%" fill="#000" />
   <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="20" fill="white">Baumgartner</text>
   <text x="50%" y="70%" dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="14" fill="white">Software</text>
 </svg>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -8,10 +8,11 @@
       body {
         font-family: sans-serif;
         margin: 0;
-        background-color: #f5f5f5;
+        color: #000;
+        background-color: #fff;
       }
       header {
-        background-color: #0F4C81;
+        background-color: #000;
         color: #fff;
         padding: 1rem;
         display: flex;
@@ -39,6 +40,25 @@
         padding: 2rem 0;
         color: #777;
         font-size: 0.9rem;
+      }
+      @media (max-width: 600px) {
+        header {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+        header nav {
+          margin-top: 0.5rem;
+        }
+        header nav a {
+          display: block;
+          margin: 0.25rem 0;
+        }
+        main {
+          margin: 1rem;
+        }
+        iframe {
+          max-width: 100%;
+        }
       }
     </style>
   </head>

--- a/src/pages/kontakt.md
+++ b/src/pages/kontakt.md
@@ -7,4 +7,4 @@ layout: ../layouts/BaseLayout.astro
 
 Nutzen Sie das folgende Formular, um uns zu erreichen:
 
-<iframe src="https://docs.google.com/forms/d/e/YOUR_FORM_ID/viewform?embedded=true" width="640" height="800" frameborder="0" marginheight="0" marginwidth="0">Wird geladen…</iframe>
+<iframe src="https://docs.google.com/forms/d/e/YOUR_FORM_ID/viewform?embedded=true" style="width:100%;max-width:640px;height:800px;" frameborder="0" marginheight="0" marginwidth="0">Wird geladen…</iframe>


### PR DESCRIPTION
## Summary
- switch base layout colors to black and white
- add mobile responsive styles
- update logo background to black
- make contact form iframe responsive

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687f625fa1a88330a7bdeb722b5f3bee