### PR TITLE
Fix invalid YAML in impressum

### DIFF
--- a/src/pages/impressum.md
+++ b/src/pages/impressum.md
@@ -1,7 +1,8 @@
 ---
 title: Impressum
 layout: ../layouts/BaseLayout.astro
-import VAT from '../../umsatzsteuer-id.md'
+setup: |
+  import VAT from '../../umsatzsteuer-id.md'
 ---
 
 # Impressum


### PR DESCRIPTION
## Summary
- fix frontmatter in `impressum.md` using `setup` block to import VAT snippet

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_68801a03fc2c8330ae45944d8ff37651