### PR TITLE
Add detailed company info to impressum and footer

### DIFF
--- a/impressum-info.md
+++ b/impressum-info.md
@@ -1,0 +1,30 @@
+Pflichtangaben auf der Website: Was muss in einem Impressum stehen?
+
+Folgende Infos sollten im Impressum enthalten sein:
+
+- Vor- und Nachnamen des Diensteanbieters.
+- Bei juristischen Personen (z. B. GmbH, AG) und Personengesellschaften (z. B. GbR, OHG): Firmierung, Firmenbezeichnung, Bezeichnung der Rechtsform sowie mindestens ein ausgeschriebener Vorname sowie der Name des Vertretungsberechtigten.
+- Adresse (Straße, Hausnummer, Postleitzahl und Ort); bei Gesellschaften der Sitz. Die Angabe eines Postfachs genügt nicht!
+- E-Mail-Adresse und ein weiteres Kommunikationsmittel, das eine schnelle elektronische Kontaktaufnahme und unmittelbare Kommunikation mit dem Dienstanbieter ermöglicht, z. B. Telefon- oder Faxnummer.
+- Register und Registernummer, falls ein Eintrag z. B. in ein Handelsregister, Vereinsregister, Partnerschaftsregister oder Genossenschaftsregister besteht.
+- Angaben zum Stamm- bzw. Grundkapital für Kapitalgesellschaften (z.B. GmbH, AG)
+- Umsatzsteueridentifikationsnummer und Wirtschafts-Identifikationsnummer, falls Sie eine solche besitzen. Die Steuernummer muss nicht angegeben werden.
+
+Unternehmensnummer (vergeben von der VBG):
+4527 8038 0355 001
+
+Betriebsnummer: 75076511
+
+Registereintrag:
+Eintragung im Registergericht: Oldenburg
+Registernummer: HRB 219785
+
+Umsatzsteuer-ID:
+Umsatzsteuer-Identifikationsnummer gemäß §27a Umsatzsteuergesetz: DE362633044
+
+Steuernummer:
+68/213/02808
+
+Gründungsdatum:
+Notar: 17.07.2023
+Schreiben vom Handelsregister: 01.08.2023

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,3 +1,6 @@
+---
+import ImpressumInfo from '../../impressum-info.md'
+---
 <!DOCTYPE html>
 <html lang="de">
   <head>
@@ -87,6 +90,9 @@
     <main>
       <slot />
     </main>
-    <footer>&copy; {new Date().getFullYear()} Baumgartner-Software</footer>
+    <footer>
+      &copy; {new Date().getFullYear()} Baumgartner-Software
+      <ImpressumInfo />
+    </footer>
   </body>
 </html>

--- a/src/pages/impressum.md
+++ b/src/pages/impressum.md
@@ -2,7 +2,7 @@
 title: Impressum
 layout: ../layouts/BaseLayout.astro
 setup: |
-  import VAT from '../../umsatzsteuer-id.md'
+  import ImpressumInfo from '../../impressum-info.md'
 ---
 
 # Impressum
@@ -13,6 +13,6 @@ Musterstraße 1
 
 E-Mail: info@example.com
 
-<VAT />
+<ImpressumInfo />
 
 Dies ist eine Demo-Seite.

--- a/umsatzsteuer-id.md
+++ b/umsatzsteuer-id.md
@@ -1,1 +1,0 @@
-Umsatzsteuer-ID: DE123456789


### PR DESCRIPTION
## Summary
- centralize company details in a single markdown file
- include this file on the Impressum page
- render the same information in the global footer

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b630f66e48330b3690476750ba16f