### PR TITLE
Update header links and Impressum page

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -75,14 +75,16 @@ import ImpressumInfo from '../../impressum-info.md'
   <body>
     <header>
       <div style="display:flex;align-items:center;">
-        <img src="/logo.svg" alt="Baumgartner Software Logo" />
-        <div>
-          <div style="font-size:1.5rem;font-weight:bold;">Baumgartner-Software</div>
-          <div style="font-size:0.9rem;">IDEEN. WACHSEN. LASSEN.</div>
-        </div>
+        <a href="/" style="display:flex;align-items:center;text-decoration:none;color:white;">
+          <img src="/logo.svg" alt="Baumgartner Software Logo" />
+          <div>
+            <div style="font-size:1.5rem;font-weight:bold;">Baumgartner-Software</div>
+            <div style="font-size:0.9rem;">IDEEN. WACHSEN. LASSEN.</div>
+          </div>
+        </a>
       </div>
       <nav>
-        <a href="/">Home</a>
+        <a href="/">Startseite</a>
         <a href="/impressum">Impressum</a>
         <a href="/kontakt">Kontakt</a>
       </nav>

--- a/src/pages/impressum.md
+++ b/src/pages/impressum.md
@@ -13,6 +13,8 @@ Musterstraße 1
 
 E-Mail: info@example.com
 
+## Firmeninformationen
+
 <ImpressumInfo />
 
 Dies ist eine Demo-Seite.


### PR DESCRIPTION
## Summary
- link logo and site name to homepage
- rename `Home` link to `Startseite`
- add section heading for Impressum information

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b79cd59f483309d8b188ef669b4c6