### PR TITLE
Add full width hero section

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -39,6 +39,23 @@ import ImpressumInfo from '../../impressum-info.md'
         box-shadow: 0 0 10px rgba(0,0,0,.1);
         border-radius: 8px;
       }
+      .hero {
+        background: url('/background-mouse-keyboard.jpg') center/cover no-repeat;
+        color: white;
+        text-align: center;
+        padding: 6rem 1rem;
+        font-weight: bold;
+      }
+      .hero p {
+        font-size: 1.2rem;
+        margin-top: 1rem;
+      }
+      .info-section {
+        background-color: #32322D;
+        color: white;
+        text-align: center;
+        padding: 2rem 1rem;
+      }
       main img {
         max-width: 100%;
         height: auto;
@@ -89,6 +106,7 @@ import ImpressumInfo from '../../impressum-info.md'
         <a href="/kontakt">Kontakt</a>
       </nav>
     </header>
+    <slot name="hero" />
     <main>
       <slot />
     </main>

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -3,9 +3,17 @@ title: Baumgartner Software
 layout: ../layouts/BaseLayout.astro
 ---
 
-# Willkommen bei Baumgartner-Software
+<div slot="hero">
+  <section class="hero">
+    <h1>Enge Zusammenarbeit, individuelle Software</h1>
+    <p>Wir realisieren Ihre Ideen mit maßgeschneiderten Lösungen und direktem Austausch – zuverlässig, praxisnah und innovativ.</p>
+  </section>
+  <section class="info-section">
+    Wir setzt auf enge Zusammenarbeit und kurze Wege, um Ihre Ideen schnell und effektiv umzusetzen. Unsere Mission ist es, maßgeschneiderte Softwarelösungen zu liefern, die den Erfolg Ihres Unternehmens nachhaltig fördern.
+  </section>
+</div>
 
-![Hero Bild](https://via.placeholder.com/800x300.png?text=Baumgartner+Software)
+# Willkommen bei Baumgartner-Software
 
 Wir bieten maßgeschneiderte Software-Lösungen und Consulting-Dienstleistungen. Unser aktueller Schwerpunkt ist die [Rocket-Meals App](https://rocket-meals.de).
 


### PR DESCRIPTION
## Summary
- include full-width hero and intro sections on the homepage
- style new hero areas
- expose hero slot in layout

## Testing
- `npm run build` *(fails: astro not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688b7bd6a8408330b24a3409b19d1e34