### PR TITLE
Add generated privacy policy page

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Datenschutzerklärung | Baumgartner Software UG</title>
+    <meta name="description" content="Erfahren Sie, wie Baumgartner Software UG personenbezogene Daten verarbeitet und schützt.">
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
+    <link rel="icon" type="image/png" href="favicon.png">
+    <link rel="apple-touch-icon" href="apple-touch-icon.png">
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-ku5A5FZjzQ+4gsuLa1+F6sB+bC5c56t2y/xO+8I2SpD+lNEwGDbVS9K6uzxhpcJn/qdNqP5pZDU8wC8N5pKA3w==" crossorigin="anonymous" referrerpolicy="no-referrer">
+</head>
+<body>
+    <header class="header">
+        <nav class="nav" role="navigation" aria-label="Hauptnavigation">
+            <div class="nav-container">
+                <div class="nav-logo">
+                    <h2>Baumgartner Software</h2>
+                </div>
+                <ul class="nav-menu" role="menubar" id="nav-menu">
+                    <li class="nav-item" role="none">
+                        <a href="index.html#home" class="nav-link" role="menuitem">Start</a>
+                    </li>
+                    <li class="nav-item" role="none">
+                        <a href="index.html#about" class="nav-link" role="menuitem">Über uns</a>
+                    </li>
+                    <li class="nav-item" role="none">
+                        <a href="index.html#products" class="nav-link" role="menuitem">Produkte</a>
+                    </li>
+                    <li class="nav-item" role="none">
+                        <a href="index.html#contact" class="nav-link" role="menuitem">Kontakt</a>
+                    </li>
+                </ul>
+                <div class="nav-toggle" id="mobile-menu" role="button" aria-label="Navigationsmenü öffnen" aria-expanded="false" aria-controls="nav-menu" tabindex="0">
+                    <span class="bar" aria-hidden="true"></span>
+                    <span class="bar" aria-hidden="true"></span>
+                    <span class="bar" aria-hidden="true"></span>
+                </div>
+            </div>
+        </nav>
+    </header>
+
+    <main class="legal-main" role="main">
+        <div class="container legal-container">
+            <section class="legal-intro" aria-labelledby="privacy-title">
+                <p class="legal-kicker">Rechtliche Hinweise</p>
+                <h1 id="privacy-title">Datenschutzerklärung</h1>
+                <p class="legal-subtitle">Transparente Informationen zum Umgang mit Ihren personenbezogenen Daten bei Baumgartner Software UG.</p>
+            </section>
+            <article id="privacy-content" class="legal-article" role="region" aria-live="polite" aria-busy="true">
+                <p class="legal-loading">Die Datenschutzerklärung wird geladen …</p>
+            </article>
+        </div>
+    </main>
+
+    <footer class="footer" role="contentinfo" aria-label="Website Footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-section">
+                    <h3>Baumgartner Software UG</h3>
+                    <p>Innovative Softwarelösungen für die digitale Zukunft</p>
+                </div>
+                <div class="footer-section">
+                    <h4>Rechtliche Informationen</h4>
+                    <p><strong>Firmenname:</strong> Baumgartner Software UG (haftungsbeschränkt)</p>
+                    <p><strong>Geschäftsführer:</strong> Nils Baumgartner</p>
+                    <p><strong>Adresse:</strong> Bernhardstraße 20, 49413</p>
+                    <p><strong>Telefon:</strong> <a href="tel:+49 170 2215430" aria-label="Telefonnummer anrufen">+49 170 2215430</a></p>
+                    <p><strong>E-Mail:</strong> <a href="mailto:info@baumgartner-software.de" aria-label="E-Mail senden">info@baumgartner-software.de</a></p>
+                </div>
+                <div class="footer-section">
+                    <h4>Handelsregister</h4>
+                    <p><strong>Registergericht:</strong> Oldenburg</p>
+                    <p><strong>Registernummer:</strong> HRB 219785</p>
+                    <p><strong>USt-IdNr:</strong> DE362633044</p>
+                </div>
+                <div class="footer-section">
+                    <h4>Produkte</h4>
+                    <ul role="list">
+                        <li role="listitem"><a href="https://rocket-meals.de" target="_blank" rel="noopener noreferrer">rocket-meals.de</a></li>
+                        <li role="listitem"><a href="index.html#contact">Individuelle Softwarelösungen</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <p>&copy; 2024 Baumgartner Software UG. Alle Rechte vorbehalten.</p>
+                <div class="footer-links" role="list">
+                    <a href="datenschutz.html" role="listitem">Datenschutz</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const container = document.getElementById('privacy-content');
+
+            if (!container) {
+                return;
+            }
+
+            const renderFallback = (markdown) => {
+                const escaped = markdown
+                    .replace(/&/g, '&amp;')
+                    .replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;');
+                container.innerHTML = `<pre class="legal-fallback">${escaped}</pre>`;
+            };
+
+            fetch('datenschutz.md')
+                .then(function (response) {
+                    if (!response.ok) {
+                        throw new Error('Die Datenschutzerklärung konnte nicht geladen werden.');
+                    }
+                    return response.text();
+                })
+                .then(function (markdown) {
+                    if (typeof marked !== 'undefined') {
+                        if (typeof marked.setOptions === 'function') {
+                            marked.setOptions({ mangle: false, headerIds: true, headerPrefix: '' });
+                        }
+                        container.innerHTML = marked.parse(markdown);
+                    } else {
+                        renderFallback(markdown);
+                    }
+                })
+                .catch(function () {
+                    container.innerHTML = '<p>Die Datenschutzerklärung konnte nicht geladen werden. Bitte versuchen Sie es später erneut.</p>';
+                })
+                .finally(function () {
+                    container.removeAttribute('aria-busy');
+                });
+        });
+    </script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/datenschutz.md
+++ b/datenschutz.md
@@ -1,0 +1,117 @@
+# Datenschutzerklärung
+
+## 1. Datenschutz auf einen Blick
+
+### Allgemeine Hinweise
+Die folgenden Hinweise geben einen einfachen Überblick darüber, was mit Ihren personenbezogenen Daten passiert, wenn Sie diese Website besuchen. Personenbezogene Daten sind alle Daten, mit denen Sie persönlich identifiziert werden können. Ausführliche Informationen zum Thema Datenschutz entnehmen Sie der nachfolgend aufgeführten Datenschutzerklärung.
+
+### Datenerfassung auf dieser Website
+**Wer ist verantwortlich für die Datenerfassung auf dieser Website?**
+Die Datenverarbeitung auf dieser Website erfolgt durch den Websitebetreiber. Die Kontaktdaten finden Sie im Abschnitt [Hinweis zur verantwortlichen Stelle](#hinweis-zur-verantwortlichen-stelle).
+
+**Wie erfassen wir Ihre Daten?**
+Ihre Daten werden zum einen dadurch erhoben, dass Sie uns diese mitteilen, z. B. indem Sie das auf der Website eingebundene Kontaktformular (Google Forms) ausfüllen. Andere Daten werden automatisch oder nach Ihrer Einwilligung beim Besuch der Website durch unsere IT-Systeme erfasst. Das sind vor allem technische Daten (z. B. Internetbrowser, Betriebssystem oder Uhrzeit des Seitenaufrufs). Die Erfassung dieser Daten erfolgt automatisch, sobald Sie diese Website betreten.
+
+**Wofür nutzen wir Ihre Daten?**
+Ein Teil der Daten wird erhoben, um eine fehlerfreie Bereitstellung der Website zu gewährleisten. Andere Daten können zur Analyse Ihres Nutzerverhaltens oder zur Bearbeitung Ihrer Anfrage verwendet werden. Sofern über die Website Verträge geschlossen oder angebahnt werden können, verarbeiten wir die übermittelten Daten zudem zur Vorbereitung entsprechender Vertragsangebote.
+
+**Welche Rechte haben Sie bezüglich Ihrer Daten?**
+Sie haben jederzeit das Recht, unentgeltlich Auskunft über Herkunft, Empfänger und Zweck Ihrer gespeicherten personenbezogenen Daten zu erhalten. Ihnen steht außerdem das Recht auf Berichtigung oder Löschung dieser Daten zu. Wenn Sie eine Einwilligung zur Datenverarbeitung erteilt haben, können Sie diese Einwilligung jederzeit für die Zukunft widerrufen. Darüber hinaus haben Sie das Recht, unter bestimmten Umständen die Einschränkung der Verarbeitung Ihrer personenbezogenen Daten zu verlangen. Des Weiteren steht Ihnen ein Beschwerderecht bei der zuständigen Aufsichtsbehörde zu. Hierzu sowie zu weiteren Fragen zum Thema Datenschutz können Sie sich jederzeit an uns wenden.
+
+## 2. Hosting
+
+### Externes Hosting (GitHub Pages)
+Diese Website wird extern bei GitHub Pages (GitHub, Inc., 88 Colin P. Kelly Jr. Street, San Francisco, CA 94107, USA; ein Dienst der Microsoft Corporation) gehostet. Die personenbezogenen Daten, die auf dieser Website erfasst werden, werden auf den Servern von GitHub gespeichert. Hierbei kann es sich v. a. um IP-Adressen, Kontaktanfragen, Meta- und Kommunikationsdaten, Vertragsdaten, Kontaktdaten, Namen, Websitezugriffe und sonstige Daten handeln, die über eine Website generiert werden.
+
+Das Hosting erfolgt zum Zwecke der Vertragserfüllung gegenüber unseren potenziellen und bestehenden Kunden (Art. 6 Abs. 1 lit. b DSGVO) sowie im Interesse einer sicheren, schnellen und effizienten Bereitstellung unseres Online-Angebots durch einen professionellen Anbieter (Art. 6 Abs. 1 lit. f DSGVO). Sofern eine entsprechende Einwilligung abgefragt wurde, erfolgt die Verarbeitung ausschließlich auf Grundlage von Art. 6 Abs. 1 lit. a DSGVO und § 25 Abs. 1 TDDDG, soweit die Einwilligung die Speicherung von Cookies oder den Zugriff auf Informationen im Endgerät des Nutzers umfasst. Die Einwilligung ist jederzeit widerrufbar.
+
+GitHub wird Ihre Daten nur insoweit verarbeiten, wie dies zur Erfüllung der Leistungspflichten erforderlich ist und unsere Weisungen in Bezug auf diese Daten befolgen. Weitere Informationen finden Sie in der Datenschutzerklärung von GitHub unter [https://docs.github.com/de/site-policy/privacy-policies/github-privacy-statement](https://docs.github.com/de/site-policy/privacy-policies/github-privacy-statement).
+
+## 3. Allgemeine Hinweise und Pflichtinformationen
+
+### Datenschutz
+Die Betreiber dieser Seiten nehmen den Schutz Ihrer persönlichen Daten sehr ernst. Wir behandeln Ihre personenbezogenen Daten vertraulich und entsprechend den gesetzlichen Datenschutzvorschriften sowie dieser Datenschutzerklärung. Wir weisen darauf hin, dass die Datenübertragung im Internet (z. B. bei der Kommunikation per E-Mail) Sicherheitslücken aufweisen kann. Ein lückenloser Schutz der Daten vor dem Zugriff durch Dritte ist nicht möglich.
+
+### Hinweis zur verantwortlichen Stelle
+Die verantwortliche Stelle für die Datenverarbeitung auf dieser Website ist:
+
+**Baumgartner Software UG (haftungsbeschränkt)**  
+Bernhardstraße 20  
+49413 Dinklage  
+Telefon: +49 170 2215430  
+E-Mail: [info@baumgartner-software.de](mailto:info@baumgartner-software.de)
+
+Verantwortliche Stelle ist die natürliche oder juristische Person, die allein oder gemeinsam mit anderen über die Zwecke und Mittel der Verarbeitung von personenbezogenen Daten (z. B. Namen, E-Mail-Adressen o. Ä.) entscheidet.
+
+### Speicherdauer
+Soweit innerhalb dieser Datenschutzerklärung keine speziellere Speicherdauer genannt wurde, verbleiben Ihre personenbezogenen Daten bei uns, bis der Zweck für die Datenverarbeitung entfällt. Wenn Sie ein berechtigtes Löschersuchen geltend machen oder eine Einwilligung zur Datenverarbeitung widerrufen, werden Ihre Daten gelöscht, sofern wir keine anderen rechtlich zulässigen Gründe für die Speicherung Ihrer personenbezogenen Daten haben (z. B. steuer- oder handelsrechtliche Aufbewahrungsfristen); im letztgenannten Fall erfolgt die Löschung nach Fortfall dieser Gründe.
+
+### Allgemeine Hinweise zu den Rechtsgrundlagen der Datenverarbeitung
+Sofern Sie in die Datenverarbeitung eingewilligt haben, verarbeiten wir Ihre personenbezogenen Daten auf Grundlage von Art. 6 Abs. 1 lit. a DSGVO bzw. Art. 9 Abs. 2 lit. a DSGVO, sofern besondere Datenkategorien nach Art. 9 Abs. 1 DSGVO verarbeitet werden. Im Falle einer ausdrücklichen Einwilligung in die Übertragung personenbezogener Daten in Drittstaaten erfolgt die Datenverarbeitung außerdem auf Grundlage von Art. 49 Abs. 1 lit. a DSGVO. Sofern Sie in die Speicherung von Cookies oder in den Zugriff auf Informationen in Ihr Endgerät (z. B. via Device-Fingerprinting) eingewilligt haben, erfolgt die Datenverarbeitung zusätzlich auf Grundlage von § 25 Abs. 1 TDDDG. Die Einwilligung ist jederzeit widerrufbar.
+
+Sind Ihre Daten zur Vertragserfüllung oder zur Durchführung vorvertraglicher Maßnahmen erforderlich, verarbeiten wir Ihre Daten auf Grundlage von Art. 6 Abs. 1 lit. b DSGVO. Des Weiteren verarbeiten wir Ihre Daten, sofern diese zur Erfüllung einer rechtlichen Verpflichtung erforderlich sind, auf Grundlage von Art. 6 Abs. 1 lit. c DSGVO. Die Datenverarbeitung kann ferner auf Grundlage unseres berechtigten Interesses nach Art. 6 Abs. 1 lit. f DSGVO erfolgen. Über die jeweils im Einzelfall einschlägigen Rechtsgrundlagen wird in den folgenden Absätzen dieser Datenschutzerklärung informiert.
+
+### Empfänger von personenbezogenen Daten
+Im Rahmen unserer Geschäftstätigkeit arbeiten wir mit verschiedenen externen Stellen zusammen. Dabei ist teilweise auch eine Übermittlung von personenbezogenen Daten an diese externen Stellen erforderlich. Wir geben personenbezogene Daten nur dann an externe Stellen weiter, wenn dies im Rahmen einer Vertragserfüllung erforderlich ist, wenn wir gesetzlich hierzu verpflichtet sind, wenn wir ein berechtigtes Interesse nach Art. 6 Abs. 1 lit. f DSGVO an der Weitergabe haben oder wenn eine sonstige Rechtsgrundlage die Datenweitergabe erlaubt. Beim Einsatz von Auftragsverarbeitern geben wir personenbezogene Daten unserer Kunden nur auf Grundlage eines gültigen Vertrags über Auftragsverarbeitung weiter. Im Falle einer gemeinsamen Verarbeitung wird ein Vertrag über gemeinsame Verarbeitung geschlossen.
+
+### Widerruf Ihrer Einwilligung zur Datenverarbeitung
+Viele Datenverarbeitungsvorgänge sind nur mit Ihrer ausdrücklichen Einwilligung möglich. Sie können eine bereits erteilte Einwilligung jederzeit widerrufen. Die Rechtmäßigkeit der bis zum Widerruf erfolgten Datenverarbeitung bleibt vom Widerruf unberührt.
+
+### Widerspruchsrecht gegen die Datenerhebung in besonderen Fällen sowie gegen Direktwerbung (Art. 21 DSGVO)
+**Wenn die Datenverarbeitung auf Grundlage von Art. 6 Abs. 1 lit. e oder f DSGVO erfolgt, haben Sie jederzeit das Recht, aus Gründen, die sich aus Ihrer besonderen Situation ergeben, gegen die Verarbeitung Ihrer personenbezogenen Daten Widerspruch einzulegen; dies gilt auch für ein auf diese Bestimmungen gestütztes Profiling.** Die jeweilige Rechtsgrundlage, auf denen eine Verarbeitung beruht, entnehmen Sie dieser Datenschutzerklärung. Wenn Sie Widerspruch einlegen, werden wir Ihre betroffenen personenbezogenen Daten nicht mehr verarbeiten, es sei denn, wir können zwingende schutzwürdige Gründe für die Verarbeitung nachweisen, die Ihre Interessen, Rechte und Freiheiten überwiegen oder die Verarbeitung dient der Geltendmachung, Ausübung oder Verteidigung von Rechtsansprüchen (Widerspruch nach Art. 21 Abs. 1 DSGVO).
+
+Werden Ihre personenbezogenen Daten verarbeitet, um Direktwerbung zu betreiben, so haben Sie das Recht, jederzeit Widerspruch gegen die Verarbeitung Sie betreffender personenbezogener Daten zum Zwecke derartiger Werbung einzulegen; dies gilt auch für das Profiling, soweit es mit solcher Direktwerbung in Verbindung steht. Wenn Sie widersprechen, werden Ihre personenbezogenen Daten anschließend nicht mehr zum Zwecke der Direktwerbung verwendet (Widerspruch nach Art. 21 Abs. 2 DSGVO).
+
+### Beschwerderecht bei der zuständigen Aufsichtsbehörde
+Im Falle von Verstößen gegen die DSGVO steht den Betroffenen ein Beschwerderecht bei einer Aufsichtsbehörde – insbesondere in dem Mitgliedstaat ihres gewöhnlichen Aufenthalts, ihres Arbeitsplatzes oder des Orts des mutmaßlichen Verstoßes – zu. Das Beschwerderecht besteht unbeschadet anderweitiger verwaltungsrechtlicher oder gerichtlicher Rechtsbehelfe.
+
+### Recht auf Datenübertragbarkeit
+Sie haben das Recht, Daten, die wir auf Grundlage Ihrer Einwilligung oder in Erfüllung eines Vertrags automatisiert verarbeiten, an sich oder an einen Dritten in einem gängigen, maschinenlesbaren Format aushändigen zu lassen. Sofern Sie die direkte Übertragung der Daten an einen anderen Verantwortlichen verlangen, erfolgt dies nur, soweit es technisch machbar ist.
+
+### Auskunft, Berichtigung, Löschung
+Sie haben im Rahmen der geltenden gesetzlichen Bestimmungen jederzeit das Recht auf unentgeltliche Auskunft über Ihre gespeicherten personenbezogenen Daten, deren Herkunft und Empfänger und den Zweck der Datenverarbeitung und ggf. ein Recht auf Berichtigung oder Löschung dieser Daten. Hierzu sowie zu weiteren Fragen zum Thema personenbezogene Daten können Sie sich jederzeit an uns wenden.
+
+### Recht auf Einschränkung der Verarbeitung
+Sie haben das Recht, die Einschränkung der Verarbeitung Ihrer personenbezogenen Daten zu verlangen. Hierzu können Sie sich jederzeit an uns wenden. Das Recht auf Einschränkung der Verarbeitung besteht in folgenden Fällen:
+
+- Wenn Sie die Richtigkeit Ihrer bei uns gespeicherten personenbezogenen Daten bestreiten, benötigen wir in der Regel Zeit, um dies zu überprüfen. Für die Dauer der Prüfung haben Sie das Recht, die Einschränkung der Verarbeitung Ihrer personenbezogenen Daten zu verlangen.
+- Wenn die Verarbeitung Ihrer personenbezogenen Daten unrechtmäßig geschah/geschieht, können Sie statt der Löschung die Einschränkung der Datenverarbeitung verlangen.
+- Wenn wir Ihre personenbezogenen Daten nicht mehr benötigen, Sie sie jedoch zur Ausübung, Verteidigung oder Geltendmachung von Rechtsansprüchen benötigen, haben Sie das Recht, statt der Löschung die Einschränkung der Verarbeitung Ihrer personenbezogenen Daten zu verlangen.
+- Wenn Sie einen Widerspruch nach Art. 21 Abs. 1 DSGVO eingelegt haben, muss eine Abwägung zwischen Ihren und unseren Interessen vorgenommen werden. Solange noch nicht feststeht, wessen Interessen überwiegen, haben Sie das Recht, die Einschränkung der Verarbeitung Ihrer personenbezogenen Daten zu verlangen.
+
+Wenn Sie die Verarbeitung Ihrer personenbezogenen Daten eingeschränkt haben, dürfen diese Daten – von ihrer Speicherung abgesehen – nur mit Ihrer Einwilligung oder zur Geltendmachung, Ausübung oder Verteidigung von Rechtsansprüchen oder zum Schutz der Rechte einer anderen natürlichen oder juristischen Person oder aus Gründen eines wichtigen öffentlichen Interesses der Europäischen Union oder eines Mitgliedstaats verarbeitet werden.
+
+### SSL- bzw. TLS-Verschlüsselung
+Diese Seite nutzt aus Sicherheitsgründen und zum Schutz der Übertragung vertraulicher Inhalte eine SSL- bzw. TLS-Verschlüsselung. Eine verschlüsselte Verbindung erkennen Sie daran, dass die Adresszeile des Browsers von „http://“ auf „https://“ wechselt und an dem Schloss-Symbol in Ihrer Browserzeile. Wenn die SSL- bzw. TLS-Verschlüsselung aktiviert ist, können die Daten, die Sie an uns übermitteln, nicht von Dritten mitgelesen werden.
+
+## 4. Datenerfassung auf dieser Website
+
+### Server-Log-Dateien
+Der Provider der Seiten erhebt und speichert automatisch Informationen in so genannten Server-Log-Dateien, die Ihr Browser automatisch an uns übermittelt. Dies sind:
+
+- Browsertyp und Browserversion
+- verwendetes Betriebssystem
+- Referrer URL
+- Hostname des zugreifenden Rechners
+- Uhrzeit der Serveranfrage
+- IP-Adresse
+
+Eine Zusammenführung dieser Daten mit anderen Datenquellen wird nicht vorgenommen. Die Erfassung dieser Daten erfolgt auf Grundlage von Art. 6 Abs. 1 lit. f DSGVO. Der Websitebetreiber hat ein berechtigtes Interesse an der technisch fehlerfreien Darstellung und der Optimierung seiner Website – hierzu müssen die Server-Log-Dateien erfasst werden.
+
+### Kontaktformular (Google Forms)
+Auf dieser Website ist ein Kontaktformular des Dienstes Google Forms eingebunden. Anbieter ist die Google Ireland Limited, Gordon House, Barrow Street, Dublin 4, Irland. Wenn Sie das Formular ausfüllen, werden Ihre Angaben an Google übermittelt und dort gespeichert. Google Forms ermöglicht es uns, Anfragen zu erfassen und zu bearbeiten. Die von Ihnen eingegebenen Daten werden zunächst bei Google gespeichert und anschließend an uns übermittelt.
+
+Die Nutzung von Google Forms erfolgt auf Grundlage unserer berechtigten Interessen an einer effizienten Bearbeitung von Nutzeranfragen sowie zur Bereitstellung eines funktionsfähigen Kontaktformulars (Art. 6 Abs. 1 lit. f DSGVO). Sofern wir Sie um Ihre Einwilligung bitten, erfolgt die Verarbeitung ausschließlich auf Grundlage von Art. 6 Abs. 1 lit. a DSGVO; die Einwilligung ist jederzeit widerrufbar.
+
+Die von Ihnen im Formular eingegebenen Daten verbleiben bei uns, bis der Zweck für die Datenspeicherung entfällt (z. B. nach abgeschlossener Bearbeitung Ihrer Anfrage), Sie uns zur Löschung auffordern oder Ihre Einwilligung widerrufen. Gesetzliche Bestimmungen – insbesondere Aufbewahrungsfristen – bleiben unberührt. Weitere Informationen finden Sie in der Datenschutzerklärung von Google unter [https://policies.google.com/privacy](https://policies.google.com/privacy).
+
+### Anfragen per E-Mail oder Telefon
+Wenn Sie uns per E-Mail oder Telefon kontaktieren, wird Ihre Anfrage inklusive aller daraus hervorgehenden personenbezogenen Daten (Name, Anfrage) zum Zweck der Bearbeitung Ihres Anliegens bei uns gespeichert und verarbeitet. Diese Daten geben wir nicht ohne Ihre Einwilligung weiter.
+
+Die Verarbeitung dieser Daten erfolgt auf Grundlage von Art. 6 Abs. 1 lit. b DSGVO, sofern Ihre Anfrage mit der Erfüllung eines Vertrags zusammenhängt oder zur Durchführung vorvertraglicher Maßnahmen erforderlich ist. In allen anderen Fällen beruht die Verarbeitung auf unserem berechtigten Interesse an der effektiven Bearbeitung der an uns gerichteten Anfragen (Art. 6 Abs. 1 lit. f DSGVO) oder auf Ihrer Einwilligung (Art. 6 Abs. 1 lit. a DSGVO), sofern diese abgefragt wurde. Die von Ihnen an uns per Kontaktanfragen übersandten Daten verbleiben bei uns, bis Sie uns zur Löschung auffordern, Ihre Einwilligung zur Speicherung widerrufen oder der Zweck für die Datenspeicherung entfällt.
+
+### Cookies und vergleichbare Technologien
+Unsere Website verwendet derzeit nur technisch notwendige Cookies, um die Stabilität und Sicherheit der Seite sicherzustellen. Soweit wir zukünftig zusätzliche Cookies einsetzen, werden wir Sie hierüber informieren und – sofern erforderlich – Ihre Einwilligung einholen. Die Speicherung notwendiger Cookies erfolgt auf Grundlage von Art. 6 Abs. 1 lit. f DSGVO, da der Websitebetreiber ein berechtigtes Interesse an der technisch fehlerfreien und optimierten Bereitstellung seiner Dienste hat.
+
+### Quelle
+Diese Datenschutzerklärung basiert in Teilen auf Vorlagen von [e-recht24.de](https://www.e-recht24.de) und wurde für die Website von Baumgartner Software individuell angepasst.

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
                 <div class="nav-logo">
                     <h2>Baumgartner Software</h2>
                 </div>
-                <ul class="nav-menu" role="menubar">
+                <ul class="nav-menu" role="menubar" id="nav-menu">
                     <li class="nav-item" role="none">
                         <a href="#home" class="nav-link" role="menuitem" aria-label="Zur Startseite">Start</a>
                     </li>
@@ -207,6 +207,9 @@
             </div>
             <div class="footer-bottom">
                 <p>&copy; 2024 Baumgartner Software UG. Alle Rechte vorbehalten.</p>
+                <div class="footer-links" role="list">
+                    <a href="datenschutz.html" role="listitem">Datenschutz</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/style.css
+++ b/style.css
@@ -420,6 +420,111 @@ body {
     display: block;
 }
 
+/* Legal Pages */
+.legal-main {
+    padding-top: 120px;
+    padding-bottom: 80px;
+    background: #f3f4f6;
+    min-height: 100vh;
+}
+
+.legal-container {
+    max-width: 960px;
+}
+
+.legal-intro {
+    text-align: center;
+    margin-bottom: 2.5rem;
+}
+
+.legal-kicker {
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: #6366f1;
+    font-weight: 600;
+    font-size: 0.85rem;
+    margin-bottom: 0.75rem;
+}
+
+.legal-intro h1 {
+    font-size: 2.75rem;
+    font-weight: 700;
+    color: #1f2937;
+    margin-bottom: 1rem;
+}
+
+.legal-subtitle {
+    color: #4b5563;
+    font-size: 1.1rem;
+    max-width: 680px;
+    margin: 0 auto;
+}
+
+.legal-article {
+    background: white;
+    border-radius: 20px;
+    padding: 2.5rem;
+    box-shadow: 0 30px 60px rgba(15, 23, 42, 0.12);
+    line-height: 1.8;
+    color: #374151;
+}
+
+.legal-article h2 {
+    font-size: 2rem;
+    margin-top: 2.5rem;
+    margin-bottom: 1rem;
+    color: #1f2937;
+}
+
+.legal-article h2:first-child {
+    margin-top: 0;
+}
+
+.legal-article h3 {
+    font-size: 1.35rem;
+    margin-top: 1.5rem;
+    margin-bottom: 0.75rem;
+    color: #1f2937;
+}
+
+.legal-article p {
+    margin-bottom: 1rem;
+}
+
+.legal-article ul {
+    margin: 1rem 0 1.5rem 1.5rem;
+    color: #4b5563;
+}
+
+.legal-article ul li {
+    margin-bottom: 0.5rem;
+}
+
+.legal-article a {
+    color: #6366f1;
+    text-decoration: none;
+    transition: color 0.3s ease;
+}
+
+.legal-article a:hover {
+    color: #4f46e5;
+}
+
+.legal-loading {
+    text-align: center;
+    color: #6b7280;
+    margin: 2rem 0;
+}
+
+.legal-fallback {
+    background: #f9fafb;
+    padding: 1.5rem;
+    border-radius: 16px;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    font-family: ui-monospace, SFMono-Regular, SFMono, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+}
+
 /* Footer */
 .footer {
     background: #1f2937;
@@ -466,8 +571,12 @@ body {
 .footer-bottom {
     border-top: 1px solid #374151;
     padding-top: 1rem;
-    text-align: center;
     color: #9ca3af;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
 }
 
 /* Mobile Responsive */
@@ -562,6 +671,28 @@ body {
         padding: 10px 20px;
         font-size: 0.9rem;
     }
+
+    .legal-main {
+        padding-top: 110px;
+        padding-bottom: 60px;
+    }
+
+    .legal-intro h1 {
+        font-size: 2.2rem;
+    }
+
+    .legal-subtitle {
+        font-size: 1rem;
+    }
+
+    .legal-article {
+        padding: 2rem;
+    }
+
+    .footer-links {
+        flex-direction: column;
+        gap: 0.5rem;
+    }
 }
 
 @media (max-width: 480px) {
@@ -617,4 +748,38 @@ body {
         width: 100%;
         height: 800px;
     }
+
+    .legal-main {
+        padding-top: 100px;
+        padding-bottom: 50px;
+    }
+
+    .legal-article {
+        padding: 1.5rem;
+    }
+
+    .legal-intro h1 {
+        font-size: 1.8rem;
+    }
+
+    .legal-subtitle {
+        font-size: 0.95rem;
+    }
 }
+
+.footer-links {
+    display: flex;
+    gap: 1.5rem;
+}
+
+.footer-links a {
+    color: #fbbf24;
+    text-decoration: none;
+    font-weight: 500;
+    transition: color 0.3s ease;
+}
+
+.footer-links a:hover {
+    color: #fcd34d;
+}
+


### PR DESCRIPTION
## Summary
- add a dedicated Datenschutzerklärung page that loads its content from a markdown source via marked.js
- write the privacy policy markdown tailored to Baumgartner Software UG
- style the legal content layout and link the new page from the existing site footer

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68cb43e2cb70833081129f85a4ade674